### PR TITLE
Add retry logic to Binance WebSocket feed

### DIFF
--- a/binance_feed/feed.py
+++ b/binance_feed/feed.py
@@ -22,25 +22,58 @@ _log = get_logger(__name__)
 class BinanceFeed:
     """Streams Binance depth & trade events into an asyncio.Queue."""
 
-    def __init__(self, symbol: str, queue: "asyncio.Queue[dict[str, Any]]") -> None:
+    def __init__(
+        self,
+        symbol: str,
+        queue: "asyncio.Queue[dict[str, Any]]",
+        max_retries: int | None = None,
+        retry_delay: float | None = None,
+    ) -> None:
         self.symbol = symbol.lower()
         self._queue = queue
         self._ws_url = f"wss://stream.binance.com:9443/stream?streams={self.symbol}@depth@100ms/{self.symbol}@trade"
         self._task: asyncio.Task | None = None
+        self._max_retries = (
+            max_retries if max_retries is not None else settings.WS_MAX_RETRIES
+        )
+        self._retry_delay = (
+            retry_delay if retry_delay is not None else settings.WS_RETRY_DELAY
+        )
 
     async def _listen(self) -> None:
-        async with aiohttp.ClientSession() as session, session.ws_connect(self._ws_url) as ws:
-            _log.info("Binance WebSocket connected for %s", self.symbol.upper())
-            async for msg in ws:
-                if msg.type != aiohttp.WSMsgType.TEXT:
-                    continue
-                data = json.loads(msg.data)
-                stream = data.get("stream", "")
-                payload = data.get("data", {})
-                if stream.endswith("@depth"):
-                    await self._queue.put({"type": "depth", "data": payload})
-                elif stream.endswith("@trade"):
-                    await self._queue.put({"type": "trade", "data": payload})
+        attempt = 0
+        delay = self._retry_delay
+        while True:
+            try:
+                async with aiohttp.ClientSession() as session:
+                    async with session.ws_connect(self._ws_url) as ws:
+                        _log.info(
+                            "Binance WebSocket connected for %s", self.symbol.upper()
+                        )
+                        async for msg in ws:
+                            if msg.type != aiohttp.WSMsgType.TEXT:
+                                continue
+                            data = json.loads(msg.data)
+                            stream = data.get("stream", "")
+                            payload = data.get("data", {})
+                            if stream.endswith("@depth"):
+                                await self._queue.put({"type": "depth", "data": payload})
+                            elif stream.endswith("@trade"):
+                                await self._queue.put({"type": "trade", "data": payload})
+            except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+                attempt += 1
+                _log.warning(
+                    "WebSocket error for %s: %s", self.symbol.upper(), exc
+                )
+                if attempt >= self._max_retries:
+                    _log.error("Max retries exceeded for %s", self.symbol.upper())
+                    break
+                _log.info("Reconnecting in %.1f seconds", delay)
+                await asyncio.sleep(delay)
+                delay *= 2
+            else:
+                attempt = 0
+                delay = self._retry_delay
 
     async def start(self) -> None:
         if self._task is None or self._task.done():

--- a/settings/config.py
+++ b/settings/config.py
@@ -19,5 +19,7 @@ class Settings(BaseSettings):
     KAPPA_CRIT: float = Field(1.0, env="KAPPA_CRIT")
     TELEGRAM_TOKEN: str = Field(..., env="TELEGRAM_TOKEN")
     TELEGRAM_CHAT_ID: str = Field(..., env="TELEGRAM_CHAT_ID")
+    WS_MAX_RETRIES: int = Field(5, env="WS_MAX_RETRIES")
+    WS_RETRY_DELAY: float = Field(1.0, env="WS_RETRY_DELAY")
 
 settings = Settings()  # singleton


### PR DESCRIPTION
## Summary
- add exponential backoff retry loop for Binance WebSocket feed
- make retry limits configurable via settings

## Testing
- `python -m py_compile binance_feed/feed.py settings/config.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fadea3fe083299cabdad1079476fa