### PR TITLE
feat: add stoppable scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,22 @@ graph TD
     Settings --> TelegramNotifier
 ```
 
+## Scheduler Usage
+
+```python
+import asyncio
+from scheduler.scheduler import Scheduler
+
+async def main() -> None:
+    sched = Scheduler()
+    stop_task = sched.start()  # non-blocking
+    # ... application runs ...
+    sched.stop()
+    await stop_task
+
+asyncio.run(main())
+```
+
 ## Metrics
 
 `MetricEngine` derives several microstructure features from buffered Binance


### PR DESCRIPTION
## Summary
- make Scheduler non-blocking and add stop method
- document Scheduler usage and shutdown

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fb1d97a08832993cb34eaf937c4ea