### PR TITLE
Handle errors when notifying Telegram

### DIFF
--- a/telegram_notifier/notifier.py
+++ b/telegram_notifier/notifier.py
@@ -7,6 +7,7 @@
 #@end
 
 from typing import Dict, Any
+import asyncio
 import telegram
 from settings.config import settings
 from util.logger import get_logger
@@ -19,6 +20,18 @@ class TelegramNotifier:
     def __init__(self):
         self._bot = telegram.Bot(token=settings.TELEGRAM_TOKEN)
 
-    def send_alert(self, regime: str, metrics: Dict[str, Any]) -> None:
+    async def send_alert(self, regime: str, metrics: Dict[str, Any]) -> None:
+        """Send an alert message to Telegram.
+
+        Tries to send the message twice before giving up and logging the
+        failure. Errors from the Telegram API are caught and logged.
+        """
         text = f"Regime changed to {regime}\nMetrics: {metrics}"
-        self._bot.send_message(chat_id=settings.TELEGRAM_CHAT_ID, text=text)
+        for attempt in range(2):
+            try:
+                await self._bot.send_message(chat_id=settings.TELEGRAM_CHAT_ID, text=text)
+                break
+            except telegram.error.TelegramError as exc:  # pragma: no cover - depends on external service
+                _log.error("Failed to send Telegram message: %s", exc)
+                if attempt == 0:
+                    await asyncio.sleep(1)


### PR DESCRIPTION
## Summary
- make Telegram notifier send alerts asynchronously
- retry once on Telegram API failure and log errors

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fb33f7a748329bfbe14e79fa4ff5a