### PR TITLE
Add tests and metrics plots

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,19 @@ Run-time enforcement can be toggled via the `LYNXCONTRACT` environment variable
 ```bash
 docker compose up --build
 ```
+
+## Testing
+
+Run the unit test suite:
+
+```bash
+pytest
+```
+
+## Running the UI
+
+Launch the Plotly Dash interface to visualise metrics:
+
+```bash
+python -m plotly_server.server
+```

--- a/plotly_server/server.py
+++ b/plotly_server/server.py
@@ -13,21 +13,62 @@ from util.logger import get_logger
 
 _log = get_logger(__name__)
 
+
 def create_app(metric_engine: "metric_engine.engine.MetricEngine") -> dash.Dash:
     app = dash.Dash(__name__)
+    ci_history: list[float] = []
+    ofi_history: list[float] = []
     app.layout = html.Div([
         dcc.Graph(id="depth-graph"),
+        dcc.Graph(id="ci-graph"),
+        dcc.Graph(id="ofi-graph"),
         dcc.Interval(id="interval", interval=1000, n_intervals=0),
     ])
 
     @app.callback(
-        dash.dependencies.Output("depth-graph", "figure"),
+        [
+            dash.dependencies.Output("depth-graph", "figure"),
+            dash.dependencies.Output("ci-graph", "figure"),
+            dash.dependencies.Output("ofi-graph", "figure"),
+        ],
         dash.dependencies.Input("interval", "n_intervals"),
     )
-    def update_graph(n):
+    def update_graph(n):  # pragma: no cover - UI callback
         df = metric_engine.buffer.depth_frame().to_pandas()
+        metrics = metric_engine.compute()
         if df.empty:
-            return px.scatter()
-        return px.line(df, x=df.index, y=["data"])
+            depth_fig = px.scatter()
+        else:
+            depth_fig = px.line(df, x=df.index, y=["data"])
+
+        ci = metrics.get("CI")
+        if ci is not None:
+            ci_history.append(ci)
+        ci_fig = (
+            px.line(x=list(range(len(ci_history))), y=ci_history, labels={"x": "t", "y": "CI"})
+            if ci_history
+            else px.scatter()
+        )
+
+        ofi = metrics.get("OFI")
+        if ofi is not None:
+            ofi_history.append(ofi)
+        ofi_fig = (
+            px.line(x=list(range(len(ofi_history))), y=ofi_history, labels={"x": "t", "y": "OFI"})
+            if ofi_history
+            else px.scatter()
+        )
+
+        return depth_fig, ci_fig, ofi_fig
 
     return app
+
+
+if __name__ == "__main__":  # pragma: no cover - manual run
+    from data_buffer.buffer import DataBuffer
+    from metric_engine.engine import MetricEngine
+
+    buffer = DataBuffer()
+    engine = MetricEngine(buffer)
+    app = create_app(engine)
+    app.run_server(debug=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+import os
+import sys
+import types
+from pathlib import Path
+
+# Ensure required environment variables for settings are present
+os.environ.setdefault("TELEGRAM_TOKEN", "dummy")
+os.environ.setdefault("TELEGRAM_CHAT_ID", "dummy")
+
+# Make project root importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+# Provide lightweight settings module to avoid pydantic dependency
+class _Settings:
+    SYMBOL = "BTCUSDT"
+    RAW_BUFFER_MINUTES = 5
+    TRADES_PER_SEC = 50
+    MU_EPS = 1e-5
+    SIGMA_LOW = 0.001
+    SIGMA_MED = 0.01
+    SIGMA_HIGH = 0.05
+    KAPPA_CRIT = 1.0
+
+settings = _Settings()
+module = types.SimpleNamespace(Settings=_Settings, settings=settings)
+sys.modules.setdefault("settings.config", module)

--- a/tests/test_data_buffer.py
+++ b/tests/test_data_buffer.py
@@ -1,0 +1,32 @@
+import polars as pl
+import pytest
+
+from data_buffer.buffer import DataBuffer
+
+
+def test_append_and_frames():
+    buf = DataBuffer(minutes=1)
+    buf.append({"type": "depth", "data": 1})
+    buf.append({"type": "trade", "data": {"p": 10}})
+
+    depth_df = buf.depth_frame()
+    trade_df = buf.trade_frame()
+
+    assert depth_df.height == 1
+    assert depth_df["data"][0] == 1
+    assert trade_df.height == 1
+    assert trade_df["data"][0]["p"] == 10
+
+
+def test_append_missing_fields_raises():
+    buf = DataBuffer()
+    with pytest.raises(KeyError):
+        buf.append({"type": "depth"})
+    with pytest.raises(KeyError):
+        buf.append({"data": 1})
+
+
+def test_append_unknown_type_raises():
+    buf = DataBuffer()
+    with pytest.raises(ValueError):
+        buf.append({"type": "other", "data": 1})

--- a/tests/test_metric_engine.py
+++ b/tests/test_metric_engine.py
@@ -1,0 +1,32 @@
+import pytest
+
+from data_buffer.buffer import DataBuffer
+from metric_engine.engine import MetricEngine
+
+
+def test_compute_basic_metrics():
+    buf = DataBuffer()
+    buf.append({'type': 'depth', 'data': 2})
+    engine = MetricEngine(buf)
+    engine._entropy = lambda df: 0.0
+    metrics = engine.compute()
+
+    assert metrics['D'] == 2
+    assert 'CI' in metrics
+    assert 'OFI' not in metrics
+
+
+def test_compute_full_metrics():
+    buf = DataBuffer()
+    buf.append({'type': 'depth', 'data': 1})
+    buf.append({'type': 'depth', 'data': 2})
+    buf.append({'type': 'trade', 'data': {'p': 100}})
+    buf.append({'type': 'trade', 'data': {'p': 101}})
+    engine = MetricEngine(buf)
+    engine._entropy = lambda df: 0.0
+    metrics = engine.compute()
+
+    assert metrics['OFI'] == 1.0
+    assert metrics['mu_dot'] == pytest.approx(10.0)
+    for key in ['phi', 'T_L', 'sigma', 'kappa']:
+        assert key in metrics

--- a/tests/test_state_engine.py
+++ b/tests/test_state_engine.py
@@ -1,0 +1,25 @@
+from state_engine.state import StateEngine
+
+
+def test_classify_flat():
+    engine = StateEngine()
+    metrics = {"CI": 0.7, "mu_dot": 0.0, "sigma": 0.0005}
+    assert engine.classify(metrics) == "FLAT"
+
+
+def test_classify_trend():
+    engine = StateEngine()
+    metrics = {"mu_dot": 0.1, "sigma": 0.005}
+    assert engine.classify(metrics) == "TREND"
+
+
+def test_classify_turbulence():
+    engine = StateEngine()
+    metrics = {"sigma": 0.06}
+    assert engine.classify(metrics) == "TURBULENCE"
+
+
+def test_regime_persistence():
+    engine = StateEngine()
+    engine.classify({"mu_dot": 0.1, "sigma": 0.005})
+    assert engine.classify({"sigma": 0.02}) == "TREND"


### PR DESCRIPTION
## Summary
- cover DataBuffer, MetricEngine and StateEngine with unit tests
- render CI and OFI metrics in the Dash UI
- document how to run tests and start the UI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fb4069900832995983d61a5769c10